### PR TITLE
Fix declaration of outputdir for groovy.

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ xsd2java {
     
     extension true
     arguments ['-verbose']
-    outputDir "${project.buildDir}/generated-sources/xsd2java"
+    outputDir file("${project.buildDir}/generated-sources/xsd2java")
 }
 ```
 


### PR DESCRIPTION
At least with gradle 8.12 the snippet only works while using file() method for outputDir.